### PR TITLE
Update url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 from os import walk, path
 
-URL = 'https://github.com/femelo/skill-ovos-pyradios'
+URL = 'https://github.com/OpenVoiceOS/ovos-skill-pyradios'
 SKILL_CLAZZ = "PyradiosSkill"  # needs to match __init__.py class name
 PYPI_NAME = "ovos-skill-pyradios"  # pip install PYPI_NAME
 


### PR DESCRIPTION
Update url in setup.py to account for the move to OVOS org

also renamed the repo to match convention and pypi name skill-ovos-pyradios -> ovos-skill-pyradios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project URL to 'https://github.com/OpenVoiceOS/ovos-skill-pyradios'.
  - Corrected `PYPI_NAME` for pip installation to 'ovos-skill-pyradios'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->